### PR TITLE
Update to 1.14 and flexibility upgrades

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import java.nio.charset.StandardCharsets
 import java.time.Year
 
 plugins {
-    id "fabric-loom" version "0.2.0-SNAPSHOT"
+    id "fabric-loom" version "0.2.3-SNAPSHOT"
     id "com.matthewprenger.cursegradle" version "1.1.2"
     id "net.minecrell.licenser" version "0.2.1"
     id "maven-publish"

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,8 @@ processResources {
 
         // add mod metadata
         expand "version": project.version , //"changelog_url": project.changelog_url,
-                "curseforge_id": project.curseforge_id, "license": project.license_header
+                "curseforge_id": project.curseforge_id, "license": project.license_header,
+                "mod_name": project.mod_name
 
         filter { String line ->
             line.replace("\"fabric\": \"*\"", "\"fabric\": \"[${project.fabric_version},)\"")

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import java.nio.charset.StandardCharsets
 import java.time.Year
 
 plugins {
-    id "fabric-loom" version "0.2.3-SNAPSHOT"
+    id "fabric-loom" version "0.2.4-SNAPSHOT"
     id "com.matthewprenger.cursegradle" version "1.1.2"
     id "net.minecrell.licenser" version "0.2.1"
     id "maven-publish"
@@ -64,12 +64,12 @@ repositories {
 dependencies {
     minecraft "com.mojang:minecraft:${minecraft_version}"
     mappings "net.fabricmc:yarn:${yarn_mappings}"
-    modCompile "net.fabricmc:fabric-loader:${loader_version}"
+    modImplementation "net.fabricmc:fabric-loader:${loader_version}"
 
-    modCompile "com.github.GlassPane:Mesh:${mesh_version}"
+    modApi "com.github.GlassPane:Mesh:${mesh_version}"
 
     //optional dependency!
-    modCompile "net.fabricmc.fabric-api:fabric-api:${fabric_version}"
+    modImplementation "net.fabricmc.fabric-api:fabric-api:${fabric_version}"
 }
 
 license {

--- a/build.gradle
+++ b/build.gradle
@@ -73,14 +73,11 @@ dependencies {
 
 license {
     header = rootProject.file("code_quality/${project.license_header}_HEADER.txt")
+
     // Apply licenses only to main source set
     sourceSets = [project.sourceSets.main]
     include "**/*.java"
-    charset = StandardCharsets.UTF_8.name()
 
-    style {
-        java = "BLOCK_COMMENT"
-    }
     newLine = false // Disables the empty line between the header and package name
     //ignoreFailures = true //Ignore failures and only print a warning on license violations
 

--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ dependencies {
 }
 
 license {
-    header = file("code_quality/${project.license_header}_HEADER.txt")
+    header = rootProject.file("code_quality/${project.license_header}_HEADER.txt")
     // Apply licenses only to main source set
     sourceSets = [project.sourceSets.main]
     include "**/*.java"
@@ -87,6 +87,13 @@ license {
     //export variables
     ext {
         year = Year.now()
-        projectDisplayName = project.archivesBaseName
+        projectDisplayName = project.name
+        projectOwners = rootProject.owners
+        if (project.license_header.contains('GPL')) {
+            if (!project.hasProperty("gpl_version")) {
+                throw new RuntimeException("GPL version needs to be specified through the 'gpl_version' property")
+            }
+            gplVersion = project.gpl_version
+        }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_8
 
 group = project.maven_group
-archivesBaseName = project.name.toLowerCase(Locale.ROOT)
+archivesBaseName = project.name
 version = System.getenv("TRAVIS_TAG") ?: project.mod_version
 println("Setting version: " + version)
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_8
 
-group = "com.github.GlassPane"
-archivesBaseName = "Fabric-Base-Mod"
+group = project.maven_group
+archivesBaseName = project.name.toLowerCase(Locale.ROOT)
 version = System.getenv("TRAVIS_TAG") ?: project.mod_version
 println("Setting version: " + version)
 
@@ -31,8 +31,8 @@ processResources {
         include "fabric.mod.json"
 
         // add mod metadata
-        expand "version": project.version /*, "changelog_url": project.changelog_url,
-                "curseforge_id": project.curseforge_id, "license": project.license_header*/
+        expand "version": project.version , //"changelog_url": project.changelog_url,
+                "curseforge_id": project.curseforge_id, "license": project.license_header
 
         filter { String line ->
             line.replace("\"fabric\": \"*\"", "\"fabric\": \"[${project.fabric_version},)\"")

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,11 @@ version = System.getenv("TRAVIS_TAG") ?: project.mod_version
 println("Setting version: " + version)
 
 apply from: "https://raw.githubusercontent.com/NerdHubMC/Gradle-Scripts/master/scripts/fabric/basic_project.gradle"
-apply from: "https://raw.githubusercontent.com/NerdHubMC/Gradle-Scripts/master/scripts/fabric/dependencies/development_suite.gradle"
+try {
+    apply from: "https://raw.githubusercontent.com/NerdHubMC/Gradle-Scripts/master/scripts/fabric/dependencies/${minecraft_version}/development_suite.gradle"
+} catch (MissingResourceException e) {
+    System.err.println(e.message)
+}
 
 processResources {
     // this will ensure that this task is redone when there"s a change

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ dependencies {
     modCompile "com.github.GlassPane:Mesh:${mesh_version}"
 
     //optional dependency!
-    modCompile "net.fabricmc:fabric:${fabric_version}"
+    modCompile "net.fabricmc.fabric-api:fabric-api:${fabric_version}"
 }
 
 license {

--- a/code_quality/GPL_HEADER.txt
+++ b/code_quality/GPL_HEADER.txt
@@ -1,0 +1,15 @@
+${projectDisplayName}
+Copyright (C) ${year} ${projectOwners}
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version ${gplVersion} of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses>.

--- a/code_quality/LGPL_HEADER.txt
+++ b/code_quality/LGPL_HEADER.txt
@@ -1,0 +1,15 @@
+${projectDisplayName}
+Copyright (C) ${year} ${projectOwners}
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version ${gplVersion} of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program; If not, see <https://www.gnu.org/licenses>.

--- a/code_quality/MIT_HEADER.txt
+++ b/code_quality/MIT_HEADER.txt
@@ -1,5 +1,5 @@
 ${projectDisplayName}
-Copyright (C) ${year} GlassPane
+Copyright (C) ${year} ${projectOwners}
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,11 @@
 # General
 # see https://modmuss50.me/fabric.html
-minecraft_version=1.14
-yarn_mappings=1.14+build.21
-loader_version=0.4.7+build.147
+minecraft_version=1.14.2
+yarn_mappings=1.14.2+build.7
+loader_version=0.4.8+build.155
 
 #Fabric api
-fabric_version=0.2.7+build.127
+fabric_version=0.3.0+build.181
 
 # Base properties
 mod_name = Fabric Base Mod

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,9 @@ loader_version=0.3.7.109
 fabric_version=0.2.3.108
 
 # Base properties
+mod_name = Fabric-Base-Mod
 mod_version = 1.0.0-SNAPSHOT
+owners = GlassPane
 maven_group = io.github.GlassPane
 
 #Other Dependencies

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,6 +20,7 @@ mesh_version = 1.0.0-SNAPSHOT
 license_header = MIT
 # FIXME set to the project's actual id
 curseforge_id = xxx
+curseforge_versions = 1.14; 1.14.1; 1.14.2
 release_type = release
 
 # Sets default memory used for gradle commands. Can be overridden by user or command line properties.

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,13 +7,21 @@ loader_version=0.3.7.109
 #Fabric api
 fabric_version=0.2.3.108
 
-#Publishing
+# Base properties
 mod_version = 1.0.0-SNAPSHOT
-license_header = MIT
-#curseforge_id =
-release_type = release
+maven_group = io.github.GlassPane
 
 #Other Dependencies
 mesh_version = 1.0.0-SNAPSHOT
+
+#Publishing
+license_header = MIT
+# FIXME set to the project's actual id
+curseforge_id = xxx
+release_type = release
+
+# Sets default memory used for gradle commands. Can be overridden by user or command line properties.
+# This is required to provide enough memory for the Minecraft decompilation process.
+org.gradle.jvmargs = -Xmx5G
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,11 @@
-#General
-#see https://modmuss50.me/fabric.html
-minecraft_version=19w09a
-yarn_mappings=19w09a.2
-loader_version=0.3.7.109
+# General
+# see https://modmuss50.me/fabric.html
+minecraft_version=1.14
+yarn_mappings=1.14+build.21
+loader_version=0.4.7+build.147
 
 #Fabric api
-fabric_version=0.2.3.108
+fabric_version=0.2.7+build.127
 
 # Base properties
 mod_name = Fabric-Base-Mod

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ loader_version=0.4.7+build.147
 fabric_version=0.2.7+build.127
 
 # Base properties
-mod_name = Fabric-Base-Mod
+mod_name = Fabric Base Mod
 mod_version = 1.0.0-SNAPSHOT
 owners = GlassPane
 maven_group = io.github.GlassPane

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,6 +24,6 @@ release_type = release
 
 # Sets default memory used for gradle commands. Can be overridden by user or command line properties.
 # This is required to provide enough memory for the Minecraft decompilation process.
-org.gradle.jvmargs = -Xmx5G
+org.gradle.jvmargs = -Xmx2G
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Sun May 12 13:31:56 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun May 12 13:31:56 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,4 +8,4 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
-rootProject.name = 'Fabric-Base-Mod'
+rootProject.name = mod_name

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,4 +8,4 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
-rootProject.name = mod_name
+rootProject.name = mod_name.replace(' ', '-')

--- a/src/main/java/com/github/glasspane/basemod/mixin/client/package-info.java
+++ b/src/main/java/com/github/glasspane/basemod/mixin/client/package-info.java
@@ -1,1 +1,0 @@
-package com.github.glasspane.basemod.mixin.client;

--- a/src/main/java/com/github/glasspane/basemod/mixin/common/package-info.java
+++ b/src/main/java/com/github/glasspane/basemod/mixin/common/package-info.java
@@ -1,1 +1,0 @@
-package com.github.glasspane.basemod.mixin.common;

--- a/src/main/java/io/github/glasspane/basemod/BaseMod.java
+++ b/src/main/java/io/github/glasspane/basemod/BaseMod.java
@@ -1,4 +1,4 @@
-package com.github.glasspane.basemod;
+package io.github.glasspane.basemod;
 
 import com.github.glasspane.mesh.api.annotation.CalledByReflection;
 import net.fabricmc.api.ModInitializer;

--- a/src/main/java/io/github/glasspane/basemod/mixin/client/package-info.java
+++ b/src/main/java/io/github/glasspane/basemod/mixin/client/package-info.java
@@ -1,0 +1,1 @@
+package io.github.glasspane.basemod.mixin.client;

--- a/src/main/java/io/github/glasspane/basemod/mixin/common/package-info.java
+++ b/src/main/java/io/github/glasspane/basemod/mixin/common/package-info.java
@@ -1,0 +1,1 @@
+package io.github.glasspane.basemod.mixin.common;

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -12,7 +12,7 @@
     "mesh": "*"
   },
   "mixins": {
-    "client": "base_mod.client.json",
-    "common": "base_mod.common.json"
+    "client": "mixins.base_mod.client.json",
+    "common": "mixins.base_mod.common.json"
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,18 +1,33 @@
 {
+  "schemaVersion": 1,
   "id": "fabric_base_mod",
-  "name": "Fabric Base Mod",
+  "name": "${mod_name}",
   "description": "Basic Mod Template for Fabric Mods",
   "version": "${version}",
-  "side": "universal",
-  "initializers": [
-    "io.github.glasspane.basemod.BaseMod"
+  "license": "${license}",
+
+  "environment": "*",
+  "entrypoints": {
+    "client": [
+
+    ],
+    "main": [
+      "io.github.glasspane.basemod.BaseMod"
+    ]
+  },
+  "mixins": [
+    {
+      "environment": "client",
+      "config": "mixins.base_mod.client.json"
+    },
+    {
+      "environment": "*",
+      "config": "mixins.base_mod.common.json"
+    }
   ],
-  "requires": {
+
+  "depends": {
     "fabric": "*",
     "mesh": "*"
-  },
-  "mixins": {
-    "client": "mixins.base_mod.client.json",
-    "common": "mixins.base_mod.common.json"
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -5,7 +5,7 @@
   "version": "${version}",
   "side": "universal",
   "initializers": [
-    "com.github.glasspane.basemod.BaseMod"
+    "io.github.glasspane.basemod.BaseMod"
   ],
   "requires": {
     "fabric": "*",

--- a/src/main/resources/mixins.base_mod.client.json
+++ b/src/main/resources/mixins.base_mod.client.json
@@ -1,6 +1,6 @@
 {
   "required": true,
-  "package": "com.github.glasspane.basemod.mixin.client",
+  "package": "io.github.glasspane.basemod.mixin.client",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
 

--- a/src/main/resources/mixins.base_mod.client.json
+++ b/src/main/resources/mixins.base_mod.client.json
@@ -3,7 +3,7 @@
   "package": "com.github.glasspane.basemod.mixin.client",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
-      "MixinItemModels"
+
   ],
   "injectors": {
     "defaultRequire": 1

--- a/src/main/resources/mixins.base_mod.common.json
+++ b/src/main/resources/mixins.base_mod.common.json
@@ -3,8 +3,7 @@
   "package": "com.github.glasspane.basemod.mixin.common",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
-      "MixinLivingEntity",
-      "MixinMobEntity"
+
   ],
   "injectors": {
     "defaultRequire": 1

--- a/src/main/resources/mixins.base_mod.common.json
+++ b/src/main/resources/mixins.base_mod.common.json
@@ -1,6 +1,6 @@
 {
   "required": true,
-  "package": "com.github.glasspane.basemod.mixin.common",
+  "package": "io.github.glasspane.basemod.mixin.common",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
 


### PR DESCRIPTION
- Most project attributes have been moved to properties. Properties have been rearranged, the ones that are changed most often are at the top of the file. *Note: I moved the project name to a property, intellij's analysis trips over it sometimes. I can revert that if you want.*
- The fabric.mod.json file has been updated to version 1, and more attributes are filled in by gradle.
- License headers for GPL and LGPL have been added, with a templated copyright owner.
- The group domain has been changed from `com.github` to `io.github`, as that's the website most of us actually own.
- The mixin json files have been prepended with `mixins.`, to 1) make their purpose more explicit and 2) let them be picked up by the minecraft dev plugin.
